### PR TITLE
Add support for immutable variables

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2904,6 +2904,38 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 		return;
 	}
 
+	{
+		auto check_immutable_assignment = [&](const GDScriptParser::IdentifierNode *id, bool allow_reference_types) {
+			const GDScriptParser::DataType &id_type = id->datatype;
+			if (allow_reference_types && (id_type.kind == GDScriptParser::DataType::CLASS || id_type.builtin_type == Variant::ARRAY || id_type.builtin_type == Variant::DICTIONARY || id_type.builtin_type == Variant::OBJECT)) {
+				return;
+			}
+			using Src = GDScriptParser::IdentifierNode::Source;
+			if ((id->source == Src::LOCAL_VARIABLE || id->source == Src::MEMBER_VARIABLE || id->source == Src::STATIC_VARIABLE || id->source == Src::INHERITED_VARIABLE) && id->variable_source && id->variable_source->is_immutable) {
+				push_error(vformat(R"(The immutable variable "%s" can only be assigned inline.)", id->name), p_assignment->assignee);
+			} else if (id->source == Src::FUNCTION_PARAMETER && id->parameter_source && id->parameter_source->is_immutable) {
+				push_error(vformat(R"(Cannot assign to immutable function parameter "%s". Remove the "let" to make it mutable.)", id->name), p_assignment->assignee);
+			}
+		};
+
+		if (p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
+			check_immutable_assignment(static_cast<const GDScriptParser::IdentifierNode *>(p_assignment->assignee), false);
+		} else if (p_assignment->assignee->type == GDScriptParser::Node::SUBSCRIPT) {
+			GDScriptParser::SubscriptNode *sub = static_cast<GDScriptParser::SubscriptNode *>(p_assignment->assignee);
+			if (sub->is_attribute) {
+				check_immutable_assignment(sub->attribute, false);
+			}
+			if (sub->base->type == GDScriptParser::Node::IDENTIFIER) {
+				check_immutable_assignment(static_cast<const GDScriptParser::IdentifierNode *>(sub->base), true);
+			} else if (sub->base->type == GDScriptParser::Node::SUBSCRIPT) {
+				const GDScriptParser::SubscriptNode *base = static_cast<const GDScriptParser::SubscriptNode *>(sub->base);
+				if (base->is_attribute) {
+					check_immutable_assignment(base->attribute, true);
+				}
+			}
+		}
+	}
+
 	GDScriptParser::DataType assignee_type = p_assignment->assignee->get_datatype();
 
 	if (assignee_type.is_constant) {
@@ -3701,6 +3733,43 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			}
 		}
 #endif // DEBUG_ENABLED
+
+		// Check for attempts to use .set() or .set_deferred() on read-only variables.
+		if ((p_call->function_name == SNAME("set") || p_call->function_name == SNAME("set_deferred")) && !p_call->arguments.is_empty()) {
+			const GDScriptParser::ExpressionNode *property_arg = p_call->arguments[0];
+			if (property_arg) {
+				StringName property_name;
+				bool has_property_name = false;
+
+				if (property_arg->is_constant && property_arg->reduced_value.get_type() == Variant::STRING) {
+					property_name = property_arg->reduced_value;
+					has_property_name = true;
+				} else if (property_arg->type == GDScriptParser::Node::LITERAL) {
+					const GDScriptParser::LiteralNode *literal = static_cast<const GDScriptParser::LiteralNode *>(property_arg);
+					if (literal->value.get_type() == Variant::STRING) {
+						property_name = literal->value;
+						has_property_name = true;
+					}
+				}
+
+				if (has_property_name && base_type.kind == GDScriptParser::DataType::CLASS && base_type.class_type != nullptr) {
+					List<GDScriptParser::ClassNode *> script_classes;
+					get_class_node_current_scope_classes(base_type.class_type, &script_classes, p_call);
+
+					for (GDScriptParser::ClassNode *script_class : script_classes) {
+						if (script_class->has_member(property_name)) {
+							resolve_class_member(script_class, property_name, p_call);
+							const GDScriptParser::ClassNode::Member &member = script_class->get_member(property_name);
+
+							if (member.type == GDScriptParser::ClassNode::Member::VARIABLE && member.variable && member.variable->is_immutable) {
+								push_error(vformat(R"*(Cannot use "%s()" to modify immutable variable "%s".)*", p_call->function_name, property_name), p_call);
+							}
+							break;
+						}
+					}
+				}
+			}
+		}
 
 		call_type = return_type;
 	} else {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1566,7 +1566,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	static const char *_keywords_with_space[] = {
 		"and", "not", "or", "in", "as", "class", "class_name", "extends", "is", "func", "signal", "await",
-		"const", "enum", "static", "var", "if", "elif", "else", "for", "match", "when", "while",
+		"const", "enum", "static", "var", "let", "if", "elif", "else", "for", "match", "when", "while",
 		nullptr
 	};
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -534,6 +534,7 @@ void GDScriptParser::synchronize() {
 			case GDScriptTokenizer::Token::FUNC:
 			case GDScriptTokenizer::Token::STATIC:
 			case GDScriptTokenizer::Token::VAR:
+			case GDScriptTokenizer::Token::LET:
 			case GDScriptTokenizer::Token::TK_CONST:
 			case GDScriptTokenizer::Token::SIGNAL:
 			//case GDScriptTokenizer::Token::IF: // Can also be inside expressions.
@@ -1025,6 +1026,12 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 					current_class->has_static_data = true;
 				}
 				break;
+			case GDScriptTokenizer::Token::LET:
+				parse_class_member(&GDScriptParser::parse_immutable_variable, AnnotationInfo::VARIABLE, "variable", next_is_static);
+				if (next_is_static) {
+					current_class->has_static_data = true;
+				}
+				break;
 			case GDScriptTokenizer::Token::TK_CONST:
 				parse_class_member(&GDScriptParser::parse_constant, AnnotationInfo::CONSTANT, "constant");
 				break;
@@ -1043,8 +1050,8 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 			case GDScriptTokenizer::Token::STATIC: {
 				advance();
 				next_is_static = true;
-				if (!check(GDScriptTokenizer::Token::FUNC) && !check(GDScriptTokenizer::Token::VAR)) {
-					push_error(R"(Expected "func" or "var" after "static".)");
+				if (!check(GDScriptTokenizer::Token::FUNC) && !check(GDScriptTokenizer::Token::VAR) && !check(GDScriptTokenizer::Token::LET)) {
+					push_error(R"(Expected "func", "var", or "let" after "static".)");
 				}
 			} break;
 			case GDScriptTokenizer::Token::ANNOTATION: {
@@ -1128,13 +1135,17 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 }
 
 GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static) {
-	return parse_variable(p_is_static, true);
+	return parse_variable(p_is_static, true, false);
 }
 
-GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, bool p_allow_property) {
+GDScriptParser::VariableNode *GDScriptParser::parse_immutable_variable(bool p_is_static) {
+	return parse_variable(p_is_static, false, true);
+}
+
+GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, bool p_allow_property, bool p_is_immutable) {
 	VariableNode *variable = alloc_node<VariableNode>();
 
-	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected variable name after "var".)")) {
+	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, vformat(R"(Expected variable name after "%s".)", p_is_immutable ? "let" : "var"))) {
 		complete_extents(variable);
 		return nullptr;
 	}
@@ -1142,6 +1153,7 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 	variable->identifier = parse_identifier();
 	variable->export_info.name = variable->identifier->name;
 	variable->is_static = p_is_static;
+	variable->is_immutable = p_is_immutable;
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
 		if (check(GDScriptTokenizer::Token::NEWLINE)) {
@@ -1179,6 +1191,8 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 			push_error(R"(Expected expression for variable initial value after "=".)");
 		}
 		variable->assignments++;
+	} else if (p_is_immutable) {
+		push_error(R"(Expected "=" after immutable "let" declaration. Immutable variable must have an initial value.)");
 	}
 
 	if (p_allow_property && match(GDScriptTokenizer::Token::COLON)) {
@@ -1592,10 +1606,21 @@ bool GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 				is_rest = true;
 			}
 
+			bool is_immutable = false;
+			if (match(GDScriptTokenizer::Token::LET)) {
+				if (is_rest) {
+					push_error("The rest parameter cannot be immutable.");
+					continue;
+				}
+				is_immutable = true;
+			}
+
 			ParameterNode *parameter = parse_parameter();
 			if (parameter == nullptr) {
 				break;
 			}
+
+			parameter->is_immutable = is_immutable;
 
 			if (p_function->is_vararg()) {
 				push_error("Cannot have parameters after the rest parameter.");
@@ -1949,7 +1974,11 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 			break;
 		case GDScriptTokenizer::Token::VAR:
 			advance();
-			result = parse_variable(false, false);
+			result = parse_variable(false, false, false);
+			break;
+		case GDScriptTokenizer::Token::LET:
+			advance();
+			result = parse_immutable_variable(false);
 			break;
 		case GDScriptTokenizer::Token::TK_CONST:
 			advance();
@@ -4193,6 +4222,7 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 		{ &GDScriptParser::parse_lambda,                    nullptr,                                        PREC_NONE }, // FUNC,
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_CONTENT_TEST }, // TK_IN,
 		{ nullptr,                                          &GDScriptParser::parse_type_test,            	PREC_TYPE_TEST }, // IS,
+		{ nullptr,                                          nullptr,                                        PREC_NONE }, //LET,
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // NAMESPACE,
 		{ &GDScriptParser::parse_preload,					nullptr,                                        PREC_NONE }, // PRELOAD,
 		{ &GDScriptParser::parse_self,                   	nullptr,                                        PREC_NONE }, // SELF,

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -983,6 +983,7 @@ public:
 	};
 
 	struct ParameterNode : public AssignableNode {
+		bool is_immutable = false;
 		ParameterNode() {
 			type = PARAMETER;
 		}
@@ -1263,6 +1264,7 @@ public:
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
+		bool is_immutable = false;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
@@ -1543,7 +1545,8 @@ private:
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable(bool p_is_static);
-	VariableNode *parse_variable(bool p_is_static, bool p_allow_property);
+	VariableNode *parse_immutable_variable(bool p_is_static);
+	VariableNode *parse_variable(bool p_is_static, bool p_allow_property, bool p_is_immutable);
 	VariableNode *parse_property(VariableNode *p_variable, bool p_need_indent);
 	void parse_property_getter(VariableNode *p_variable);
 	void parse_property_setter(VariableNode *p_variable);

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -113,6 +113,7 @@ static const char *token_names[] = {
 	"func", // FUNC,
 	"in", // TK_IN,
 	"is", // IS,
+	"let", // LET,
 	"namespace", // NAMESPACE
 	"preload", // PRELOAD,
 	"self", // SELF,
@@ -512,6 +513,8 @@ GDScriptTokenizer::Token GDScriptTokenizerText::annotation() {
 	KEYWORD("if", Token::IF)                 \
 	KEYWORD("in", Token::TK_IN)              \
 	KEYWORD("is", Token::IS)                 \
+	KEYWORD_GROUP('l')                       \
+	KEYWORD("let", Token::LET)               \
 	KEYWORD_GROUP('m')                       \
 	KEYWORD("match", Token::MATCH)           \
 	KEYWORD_GROUP('n')                       \

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -118,6 +118,7 @@ public:
 			FUNC,
 			TK_IN, // Conflict with WinAPI.
 			IS,
+			LET,
 			NAMESPACE,
 			PRELOAD,
 			SELF,

--- a/modules/gdscript/tests/scripts/analyzer/errors/immutable_variables.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/immutable_variables.gd
@@ -1,0 +1,35 @@
+class ImmutableTestObject:
+	let immutable_member: float = 0.0 # Case: immutable member
+	static let immutable_static: float = 0.0 # Case: static immutable member
+	# let immutable_unassigned: float # Case: unassigned immutable member													NOT ALLOWED
+	let immutable_array: Array[float] = [0.0, 1.0, 2.0, 3.0]
+
+	func _init():
+		immutable_member = 1.0 # Case: assign immutable member															NOT ALLOWED
+		immutable_static = 1.0 # Case: assign static immutable member													NOT ALLOWED
+		immutable_array = [0.0] # Case: assign immutable pass-by-ref var												NOT ALLOWED
+		immutable_array[0] = 1.0 # Case: modify immutable pass-by-ref var's state
+		param_test(0.0) # Case call function with input for immutable parameter
+
+	# Case: function with immutable parameter & immutable parameter with default
+	func param_test(let immutable_parameter: float, let immutable_default: float = 0.0):
+		immutable_parameter = 1.0 # Case: assign immutable parameter													NOT ALLOWED
+		immutable_default = 1.0 # Case: assign immutable default parameter												NOT ALLOWED
+
+class ImmutableExtends extends ImmutableTestObject:
+	func _init():
+		immutable_member = 1.0 # Case: assign base class immutable member												NOT ALLOWED
+
+func test():
+	let immutable_local: float = 0.0 # Case: immutable local
+	immutable_local = 1.0 # Case: assign immutable local																NOT ALLOWED
+
+	# let immutable_local_unassigned: float # Case: unassigned imutable local											NOT ALLOWED
+
+	var lambda = func(let delta: float): # Case: lambda immutable parameter
+		delta = 0.0 # Case: assign immutable lambda parameter															NOT ALLOWED
+	lambda.call(0.0) # Case: call lambda with input for immutable parameter
+
+	var test:= ImmutableTestObject.new()
+	test.immutable_member = 1.0 # Case: assign object immutable member													NOT ALLOWED
+	test.set("immutable_member", 1.0) # Case: assign object immutable member via .set()									NOT ALLOWED

--- a/modules/gdscript/tests/scripts/analyzer/errors/immutable_variables.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/immutable_variables.out
@@ -1,0 +1,11 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 25: The immutable variable "immutable_local" can only be assigned inline.
+>> ERROR at line 30: Cannot assign to immutable function parameter "delta". Remove the "let" to make it mutable.
+>> ERROR at line 34: The immutable variable "immutable_member" can only be assigned inline.
+>> ERROR at line 35: Cannot use "set()" to modify immutable variable "immutable_member".
+>> ERROR at line 8: The immutable variable "immutable_member" can only be assigned inline.
+>> ERROR at line 9: The immutable variable "immutable_static" can only be assigned inline.
+>> ERROR at line 10: The immutable variable "immutable_array" can only be assigned inline.
+>> ERROR at line 16: Cannot assign to immutable function parameter "immutable_parameter". Remove the "let" to make it mutable.
+>> ERROR at line 17: Cannot assign to immutable function parameter "immutable_default". Remove the "let" to make it mutable.
+>> ERROR at line 21: The immutable variable "immutable_member" can only be assigned inline.

--- a/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_class.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_class.gd
@@ -1,0 +1,8 @@
+class A:
+	let immutable_member: float
+
+	func class_func(let immutable_param): # Case: assigned param immutable
+		pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_class.out
+++ b/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_class.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected "=" after immutable "let" declaration. Immutable variable must have an initial value.

--- a/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_local.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_local.gd
@@ -1,0 +1,2 @@
+func test():
+	let immutable_local: float

--- a/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_local.out
+++ b/modules/gdscript/tests/scripts/parser/errors/immutable_var_unassigned_local.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected "=" after immutable "let" declaration. Immutable variable must have an initial value.


### PR DESCRIPTION
Immutable variables can be declared using `let` keyword instead of `var`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
